### PR TITLE
Rewrite to add config file

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,11 +8,16 @@
 # Dependencies
 * [qb-target](https://github.com/BerkieBb/qb-target)
 * [qb-menu](https://github.com/qbcore-framework/qb-menu)
+# If not using QB-Target also add dependancy below for Polyzone
+* [PolyZone] (https://github.com/mkafrin/PolyZone)
+
 
 ## Preview
 https://streamable.com/1r6iqa
 
 # Installation
+
+*** If using QB-target comment out (lines 6-22) in the Client.main and both polyzone refrences in the fxmanifest (lines 12-13), If not using QB-target ignore target model option below**
 
 * Find this in **qb-target/config**
 * Put this in **"Config.TargetModels"** (more reliable to always keep target models in config) 

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,53 +1,74 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local SpawnVehicle = false
 
+
+------Delete below or comment out if using QB-Target
+Citizen.CreateThread(function()
+
+        local startLoc = CircleZone:Create(Config.PedCoords, 2.0, {
+        name='rental',
+        debugPoly=true,
+        useZ=true, 
+        })
+
+        startLoc:onPlayerInOut(function(isPointInside)
+        if isPointInside then
+            TriggerEvent('qb-rental:openMenu')
+        else
+            exports['qb-menu']:closeMenu()
+        end
+    end)
+
+end)
+----- Delete above or comment out if using QB-Target
+
 RegisterNetEvent('qb-rental:openMenu', function()
-    exports['qb-menu']:openMenu({
+    exports['qb-menu']:showHeader({
         {
-            header = "Rental Vehicles",
+            header = 'Rental Vehicles',
             isMenuHeader = true,
         },
         {
             id = 1,
-            header = "Return Vehicle ",
-            txt = "Return your rented vehicle.",
+            header = 'Return Vehicle ',
+            txt = 'Return your rented vehicle.',
             params = {
-                event = "qb-rental:return",
+                event = 'qb-rental:return',
             }
         },
         {
             id = 2,
-            header = "Asterope",
-            txt = "$250.00",
+            header = Config.Vehicle1,
+            txt = '$' .. Config.Vehicle1cost,
             params = {
-                event = "qb-rental:spawncar",
+                event = 'qb-rental:spawncar',
                 args = {
-                    model = 'asterope',
-                    money = 250,
+                    model = Config.Vehicle1Spawncode,
+                    money = Config.Vehicle1cost,
                 }
             }
         },
         {
             id = 3,
-            header = "Bison ",
-            txt = "$500.00",
+            header = Config.Vehicle2,
+            txt = '$' .. Config.Vehicle2cost,
             params = {
-                event = "qb-rental:spawncar",
+                event = 'qb-rental:spawncar', 
                 args = {
-                    model = 'bison',
-                    money = 500,
+                    model = Config.Vehicle2Spawncode,
+                    money = Config.Vehicle2cost,
                 }
             }
         },
         {
             id = 4,
-            header = "Sanchez",
-            txt = "$750.00",
+            header = Config.Vehicle3,
+            txt = '$' .. Config.Vehicle3cost,
             params = {
-                event = "qb-rental:spawncar",
+                event = 'qb-rental:spawncar', 
                 args = {
-                    model = 'sanchez',
-                    money = 750,
+                    model = Config.Vehicle3Spawncode,
+                    money = Config.Vehicle3cost,
                 }
             }
         },
@@ -72,57 +93,81 @@ end
 
 
 CreateNPC = function()
-    created_ped = CreatePed(5, GetHashKey('a_m_y_business_03') , 109.9739, -1088.61, 28.302, 345.64, false, true)
+    created_ped = CreatePed(5, GetHashKey('a_m_y_business_03') , Config.PedCoords, Config.PedHeading, false, true)
     FreezeEntityPosition(created_ped, true)
     SetEntityInvincible(created_ped, true)
     SetBlockingOfNonTemporaryEvents(created_ped, true)
     TaskStartScenarioInPlace(created_ped, 'WORLD_HUMAN_CLIPBOARD', 0, true)
 end
 
+
 RegisterNetEvent('qb-rental:spawncar')
 AddEventHandler('qb-rental:spawncar', function(data)
-    local money =data.money
+    local money = data.money
     local model = data.model
     local player = PlayerPedId()
-    QBCore.Functions.SpawnVehicle(model, function(vehicle)
-        SetEntityHeading(vehicle, 340.0)
-        TaskWarpPedIntoVehicle(player, vehicle, -1)
-        TriggerEvent("vehiclekeys:client:SetOwner", GetVehicleNumberPlateText(vehicle))
-        SetVehicleEngineOn(vehicle, true, true)
-        SpawnVehicle = true
-    end, vector4(111.4223, -1081.24, 29.192,340.0), true)
-    Wait(1000)
-    local vehicle = GetVehiclePedIsIn(player, false)
-    local vehicleLabel = GetDisplayNameFromVehicleModel(GetEntityModel(vehicle))
-    vehicleLabel = GetLabelText(vehicleLabel)
-    local plate = GetVehicleNumberPlateText(vehicle)
-    TriggerServerEvent('qb-rental:rentalpapers', plate, vehicleLabel, money)
+    if SpawnVehicle == false then
+        QBCore.Functions.SpawnVehicle(model, function(vehicle)
+            SetEntityHeading(vehicle, 340.0)
+            TaskWarpPedIntoVehicle(player, vehicle, -1)
+            TriggerEvent('vehiclekeys:client:SetOwner', GetVehicleNumberPlateText(vehicle))
+            SetVehicleEngineOn(vehicle, true, true)
+            SetEntityAsMissionEntity(vehicle, true, true)
+            SpawnVehicle = true
+        end, Config.VehCoords, true)
+
+        Wait(1000)
+        local vehicle = GetVehiclePedIsIn(player, false)
+        local vehicleLabel = GetDisplayNameFromVehicleModel(GetEntityModel(vehicle))
+        vehicleLabel = GetLabelText(vehicleLabel)
+        local plate = GetVehicleNumberPlateText(vehicle)
+        TriggerServerEvent('qb-rental:rentalpapers', plate, vehicleLabel, money)
+        rentedcar = vehicle
+    else
+        QBCore.Functions.Notify('You already have a vehicle rented.', 'error') 
+    end
 end)
 
 RegisterNetEvent('qb-rental:return')
 AddEventHandler('qb-rental:return', function()
     if SpawnVehicle then
-        local Player = QBCore.Functions.GetPlayerData()
-        QBCore.Functions.Notify('Returned vehicle!', 'success')
-        TriggerServerEvent('qb-rental:removepapers')
-        local car = GetVehiclePedIsIn(PlayerPedId(),true)
-        NetworkFadeOutEntity(car, true,false)
-        Citizen.Wait(2000)
-        QBCore.Functions.DeleteVehicle(car)
+        if not IsPedInAnyVehicle(PlayerPedId(), true) then
+            local currentcar = QBCore.Functions.GetClosestVehicle()
+            if currentcar ~= nil then 
+                if currentcar == rentedcar then
+                    local Player = QBCore.Functions.GetPlayerData()
+                    QBCore.Functions.Notify('Returned vehicle!', 'success')
+                    TriggerServerEvent('qb-rental:removepapers')
+                        if Config.Depositenabled then
+                            TriggerServerEvent('qb-rentals:server:depositpayout')
+                            local health = GetVehicleEngineHealth(rentedcar)  ---Health check test.
+                                if Config.Healthcheck then
+                                    TriggerServerEvent('qb-rentals:server:healthcheck', health)
+                                end
+                        end
+                    NetworkFadeOutEntity(rentedcar, true,false)
+                    Citizen.Wait(2000)
+                    QBCore.Functions.DeleteVehicle(rentedcar)
+                    SpawnVehicle = false
+                else
+                    QBCore.Functions.Notify('Please bring the vehicle back in order to return it.', 'error') 
+                end
+            end
+        end 
     else 
-        QBCore.Functions.Notify("No vehicle to return", "error")
+        QBCore.Functions.Notify('No vehicle to return', 'error')
     end
-    SpawnVehicle = false
 end)
 
-CreateThread(function()
-    blip = AddBlipForCoord(111.0112, -1088.67, 29.302)
-    SetBlipSprite (blip, 56)
-    SetBlipDisplay(blip, 4)
-    SetBlipScale  (blip, 0.5)
-    SetBlipColour (blip, 77)
-    SetBlipAsShortRange(blip, true)
+
+Citizen.CreateThread(function()
+    VehicleRental = AddBlipForCoord(111.0112, -1088.67, 29.302)
+    SetBlipSprite (VehicleRental, 56)
+    SetBlipDisplay(VehicleRental, 4)
+    SetBlipScale  (VehicleRental, 0.5)
+    SetBlipAsShortRange(VehicleRental, true)
+    SetBlipColour(VehicleRental, 77)
     BeginTextCommandSetBlipName("STRING")
-    AddTextComponentString('Vehicle Rental')
-    EndTextCommandSetBlipName(blip)
-end)
+    AddTextComponentSubstringPlayerName("Vehicle Rental")
+    EndTextCommandSetBlipName(VehicleRental)
+end) 

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,38 @@
+Config = {
+
+    Healthcheck = true, -- Charges money when vehicle comes back with health below damage.
+
+    Repaircost = 450, -- If enable is true sets repair cost for vehicles with health below damage amount.
+    Damage = 700, -- If enable is true this sets acceptable vehicle damage level on return.
+
+    Repair2 = true, -- If enabled you can set a secondary repair cost should be based on a higher health.
+    -- Ex. based on currrent config. IF vehicle health is 700 or lower you pay a $450 repair cost, elseif vehicle health is 900 to 700 pay only $250 for repairs.
+    Damage2 = 900, -- Health of secondary repair fee.
+    Repaircost2 = 250, -- Repair cost for secondary damage check.
+
+    Depositenabled = true, -- Turns on a deposit allowing player to make a portion of their money back for returning the vehicle.
+    Deposit = 500, -- Deposit given back to player when returning the vehicle **Offers incentive to return vehicle.
+
+    --Ped Spawning info
+    PedCoords = vector3(109.9739, -1088.61, 28.302), -- Ped and Polyzone location, if not using polyzone go to client main lua and comment out top part.
+    PedHeading = 345.64, -- Ped heading
+
+    --Vehicale spawning info
+    VehCoords = vector4(111.4223, -1081.24, 29.192, 340.0), -- Vehicle spawn location
+
+
+
+
+
+    Vehicle1 = 'Panto',
+    Vehicle1cost = 1500,
+    Vehicle1Spawncode = 'Panto',
+
+    Vehicle2 = 'Asea',
+    Vehicle2cost = 1500,
+    Vehicle2Spawncode = 'Asea',
+
+    Vehicle3 = 'Dilettante',
+    Vehicle3cost = 1500,
+    Vehicle3Spawncode = 'Dilettante',
+    }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -6,5 +6,13 @@ author 'Hyper'
 version '1.2.0'
 
 
-client_script 'client/main.lua'
-server_script 'server/main.lua'
+client_script {
+    'config.lua',
+    'client/main.lua',
+    '@PolyZone/client.lua',
+    '@PolyZone/CircleZone.lua',
+}
+server_script {
+    'config.lua',
+    'server/main.lua',
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,10 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
+RegisterServerEvent('qb-rentals:server:depositpayout', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    Player.Functions.AddMoney('bank', Config.Deposit)
+end)
 
 RegisterServerEvent('qb-rental:rentalpapers')
 AddEventHandler('qb-rental:rentalpapers', function(plate, model, money)
@@ -24,5 +29,22 @@ AddEventHandler('qb-rental:removepapers', function(plate, model, money)
     TriggerClientEvent('inventory:client:ItemBox', src,  QBCore.Shared.Items["rentalpapers"], 'remove')
     Player.Functions.RemoveItem('rentalpapers', 1, false, info)
 end)
+
+
+RegisterNetEvent('qb-rentals:server:healthcheck')
+AddEventHandler('qb-rentals:server:healthcheck', function(health)
+    local src = source
+    local charges = Config.Repaircost
+    local Player = QBCore.Functions.GetPlayer(src)
+    local bankBalance = Player.PlayerData.money["bank"]
+    if health <= Config.Damage then 
+            TriggerClientEvent("QBCore:Notify", src, "The car seems damaged you are being charged $"..Config.Repaircost.." for the repairs.", "error", 5000)
+            Player.Functions.RemoveMoney("bank", Config.Repaircost , "Vehicle has been sent for repairs.")
+    elseif health <= Config.Damage2 and Config.Repair2 then
+        TriggerClientEvent("QBCore:Notify", src, "The car seems damaged you are being charged $"..Config.Repaircost2.." for the repairs.", "error", 5000)
+        Player.Functions.RemoveMoney("bank", Config.Repaircost2 , "Vehicle has been sent for repairs.")
+    end
+end)
+
 
 


### PR DESCRIPTION
- Made config file for configurable options.
- Added check to force player to drive car back to rental location. **Based on closest car to rental PED
- Added check so Player can only rent 1 car at a time.
- Added Non-Qb-target support based on polyzone. **Check readme can swap between both.
- Added Damage check and repair cost, configurable and able to turn on and off in Config.
- 2 Repair cost levels, configurable and can turn only 1 off or both.
- Added deposit option, configurable and able to turn on and off in Config.  --Incentivise vehicle return
- Updated Blip.